### PR TITLE
Use correct function call for renamed function

### DIFF
--- a/Automator_Scripts/bookletPDF.py
+++ b/Automator_Scripts/bookletPDF.py
@@ -109,7 +109,7 @@ def makeBooklet(argv):
 	writeFilename = shortName + suffix
 	# writeFilename = writeFilename.encode('utf-8')
 	metaDict = getDocInfo(argv)
-	writeContext = createOutputContextWithPath(writeFilename, metaDict)
+	writeContext = createOutputContextFromPath(writeFilename, metaDict)
 	source = createPDFDocumentFromPath(argv)
 	totalPages = Quartz.CGPDFDocumentGetNumberOfPages(source)
 


### PR DESCRIPTION
I think you forgot to rename a function call while changing the function name. Fixed it.